### PR TITLE
feat: enlarge profile image on homepage

### DIFF
--- a/themes/archie/assets/css/main.css
+++ b/themes/archie/assets/css/main.css
@@ -421,7 +421,7 @@ table td{
 }
 
 .profile-image {
-    max-width: 60%;
+    max-width: 90%;
     height: auto;
     margin: 2rem 0 2rem auto;
     box-shadow: 0 4px 8px rgba(0,0,0,0.1);
@@ -429,7 +429,7 @@ table td{
 
 @media (max-width: 991px) {
     .profile-image {
-        max-width: 40%;
+        max-width: 60%;
         margin: 2rem auto;
     }
 }
@@ -486,7 +486,7 @@ hr {
 
 /* Optional: Control image size */
 .profile-image {
-  max-width: 400px;  /* Adjust maximum image width */
+  max-width: 600px;  /* Adjust maximum image width */
   width: 100%;       /* Make responsive */
 }
 

--- a/themes/archie/layouts/index.html
+++ b/themes/archie/layouts/index.html
@@ -11,7 +11,7 @@
                         <div class="col-4 d-flex align-items-center">
                             <img src="/images/calm_profile.webp"
                                  alt="Profile Picture"
-                                 width="300" height="261"
+                                 width="600" height="522"
                                  fetchpriority="high"
                                  class="profile-image">
                         </div>


### PR DESCRIPTION
## Summary

Enlarges the profile image displayed on the homepage to make it more prominent and improve the overall visual hierarchy of the page.

## Changes

**Styling (`themes/archie/assets/css/main.css`)**

- Increased profile image size dimensions
- Adjusted related spacing and layout properties

**Layout (`themes/archie/layouts/index.html`)**

- Updated homepage template to reflect profile image size changes

---

[Chat](https://open-agents.dev/sessions/s4Sz_1Xepi4ULaoG7b8cV/chats/LV5xUBmS3INYTj_kzV1Er) - Built with guidance from [karansampath](https://github.com/karansampath)